### PR TITLE
Fix Quick Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ These subagents are automatically available when placed in the `~/.claude/agents
 # Clone the repository to your Claude agents directory
 # Documents are base on the scaffold from https://github.com/wshobson/agents.git
 cd ~/.claude
-git clone https://github.com/lst97/claude-code-sub-agents.git
+git clone https://github.com/lst97/claude-code-sub-agents.git agents
 
 # Or if the directory already exists, pull the latest updates
 cd ~/.claude/agents


### PR DESCRIPTION
### **User description**
The command provided doesn't work directly because the name of this repository is not `agents` (unlike the scaffold).

The `git clone` command thus needs to explicitly specify the target directory.


___

### **PR Type**
Documentation


___

### **Description**
- Fix git clone command to specify target directory

- Ensure proper installation path for Claude agents


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["git clone command"] --> B["add target directory 'agents'"] --> C["correct installation path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix git clone target directory specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated git clone command to include target directory <code>agents</code><br> <li> Fixed installation instructions for proper directory structure</ul>


</details>


  </td>
  <td><a href="https://github.com/lst97/claude-code-sub-agents/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

